### PR TITLE
Request persistent storage when possible

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,8 +1,7 @@
 name: Deploy to Github Pages
 on:
-  push:
-    branches:
-      - main
+  release:
+    types: [published]
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -12,7 +12,7 @@
   import CardIcon from "./icons/card.svg"
   import SettingsIcon from "./icons/settings.svg"
 
-  import { loadCardsFromStorage } from "./cardsStore"
+  import { loadCardsFromStorage } from "./cardStore"
 
   let isUpdateAlertShown = false
 

--- a/src/Card.svelte
+++ b/src/Card.svelte
@@ -1,6 +1,6 @@
 <!-- Copyright (c) 2022 Ivan Teplov -->
 <script>
-  import { updateCardBackground } from "./cardsStore"
+  import { updateCardBackground } from "./cardStore"
 
   export let card
 

--- a/src/CardForm.svelte
+++ b/src/CardForm.svelte
@@ -3,7 +3,7 @@
   import Card from "./Card.svelte"
 
   import { randomCardGradient } from "./helpers/randomCardGradient"
-  import { addCard as addCardToStore, updateCard } from "./cardsStore"
+  import { addCard as addCardToStore, updateCard } from "./cardStore"
 
   import { fade } from "svelte/transition"
 

--- a/src/CardList.svelte
+++ b/src/CardList.svelte
@@ -3,7 +3,7 @@
   import Spinner from "./components/Spinner.svelte"
   import Card from "./Card.svelte"
 
-  import { cards } from "./cardsStore"
+  import { cards } from "./cardStore"
 
   import { createEventDispatcher } from "svelte"
 

--- a/src/Content.svelte
+++ b/src/Content.svelte
@@ -4,7 +4,7 @@
   import Alert from "./components/Alert.svelte"
   import CardView from "./CardView.svelte"
 
-  import { cards, removeCard } from "./cardsStore"
+  import { cards, removeCard } from "./cardStore"
 
   import CardForm from "./CardForm.svelte"
   import CardList from "./CardList.svelte"

--- a/src/Settings.svelte
+++ b/src/Settings.svelte
@@ -1,7 +1,7 @@
 <!-- Copyright (c) 2022 Ivan Teplov -->
 <script>
   import Alert from "./components/Alert.svelte"
-  import { cards, addCard } from "./cardsStore"
+  import { cards, addCard } from "./cardStore"
 
   import { version, repository } from "../package.json"
 


### PR DESCRIPTION
We're saving data into IndexedDB. However, when storage space runs low (especially on mobile devices), Chrome will automatically clean some data. That leads to having all the cards deleted. In the future, I might add an ability to create an account and sync data between a device and the account. However, what I can do at the moment is to ask browser to not delete that data automatically.